### PR TITLE
Fixing millis() overflow on timeouts

### DIFF
--- a/ModbusRtu.h
+++ b/ModbusRtu.h
@@ -481,7 +481,7 @@ void Modbus::setTimeOut( uint16_t u16timeOut)
  */
 boolean Modbus::getTimeOutState()
 {
-    return (millis() > u32timeOut);
+    return ((unsigned long)(millis() -u32timeOut) > (unsigned long)u16timeout);
 }
 
 /**
@@ -662,7 +662,7 @@ int8_t Modbus::poll()
     else
         u8current = softPort->available();
 
-    if (millis() > u32timeOut)
+    if ((unsigned long)(millis() -u32timeOut) > (unsigned long)u16timeout)
     {
         u8state = COM_IDLE;
         u8lastError = NO_REPLY;
@@ -676,10 +676,10 @@ int8_t Modbus::poll()
     if (u8current != u8lastRec)
     {
         u8lastRec = u8current;
-        u32time = millis() + T35;
+        u32time = millis();
         return 0;
     }
-    if (millis() < u32time) return 0;
+    if ((unsigned long)(millis() -u32time) > (unsigned long)T35) return 0;
 
     // transfer Serial buffer frame to auBuffer
     u8lastRec = 0;
@@ -758,10 +758,10 @@ int8_t Modbus::poll( uint16_t *regs, uint8_t u8size )
     if (u8current != u8lastRec)
     {
         u8lastRec = u8current;
-        u32time = millis() + T35;
+        u32time = millis();
         return 0;
     }
-    if (millis() < u32time) return 0;
+    if ((unsigned long)(millis() -u32time) > (unsigned long)T35) return 0;
 
     u8lastRec = 0;
     int8_t i8state = getRxBuffer();
@@ -784,7 +784,7 @@ int8_t Modbus::poll( uint16_t *regs, uint8_t u8size )
         return u8exception;
     }
 
-    u32timeOut = millis() + long(u16timeOut);
+    u32timeOut = millis();
     u8lastError = 0;
 
     // process message
@@ -974,7 +974,7 @@ void Modbus::sendTxBuffer()
     u8BufferSize = 0;
 
     // set time-out for master
-    u32timeOut = millis() + (unsigned long) u16timeOut;
+    u32timeOut = millis();
 
     // increase message counter
     u16OutCnt++;


### PR DESCRIPTION
Eliminating millis() overflow limitation by keeping millis() and using a cast to unsigned long on the comparison